### PR TITLE
fix: correct appointments route to appointment

### DIFF
--- a/app/(Root)/config/modules.ts
+++ b/app/(Root)/config/modules.ts
@@ -159,7 +159,7 @@ export const moduleConfigs: ModuleConfig[] = [
       {
         label: "Appointments",
         icon: Calendar,
-        href: "/appointments",
+        href: "/appointment",
       },
       {
         label: "Patients",


### PR DESCRIPTION
Update the href path from "/appointments" to "/appointment" to match the actual route